### PR TITLE
Three states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # Specific files/dirs to ignore for this pipeline
 */tmp/*
+_targets/*
+3_visualize/out/*
+*.DS_Store

--- a/_targets.R
+++ b/_targets.R
@@ -6,6 +6,7 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturale
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
+source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
@@ -15,9 +16,33 @@ parameter <- c('00060')
 # Targets
 list(
   # Identify oldest sites
-  tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
+  tar_target(
+    oldest_active_sites,
+    find_oldest_sites(states, parameter)
+  ),
 
-  # TODO: PULL SITE DATA HERE
+  # PULL SITE DATA
+  tar_target(
+    wi_data,
+    get_site_data(
+      sites_info = oldest_active_sites,
+      state = 'WI',
+      parameter = parameter)
+  ),
+  tar_target(
+    mn_data,
+    get_site_data(
+      sites_info = oldest_active_sites,
+      state = 'MN',
+      parameter = parameter)
+  ),
+  tar_target(
+    mi_data,
+    get_site_data(
+      sites_info = oldest_active_sites,
+      state = 'MI',
+      parameter = parameter)
+  ),
 
   # Map oldest sites
   tar_target(


### PR DESCRIPTION
* Added targets to retrieve site data for each state
* Added specified files to `.gitignore` file

``` r
> tar_make()
v skip target oldest_active_sites
v skip target site_map_png
* start target wi_data
  Retrieving data for WI-WI
* built target wi_data
* start target mn_data
  Retrieving data for MN-MN
* built target mn_data
* start target mi_data
  Retrieving data for MI-MI
x error target mi_data
* end pipeline
Error : Ugh, the internet data transfer failed! Try again.
In addition: Warning messages:
1: package 'targets' was built under R version 4.0.5 
2: package 'ggplot2' was built under R version 4.0.5 
3: package 'tibble' was built under R version 4.0.5 
4: package 'tidyr' was built under R version 4.0.5 
5: package 'readr' was built under R version 4.0.5 
6: package 'purrr' was built under R version 4.0.5 
7: package 'stringr' was built under R version 4.0.5 
8: package 'dataRetrieval' was built under R version 4.0.5 
9: 1 targets produced warnings. Run tar_meta(fields = warnings) for the messages. 
Error: callr subprocess failed: Ugh, the internet data transfer failed! Try again.
Visit https://books.ropensci.org/targets/debugging.html for debugging advice.
> tar_make()
v skip target oldest_active_sites
v skip target site_map_png
v skip target wi_data
v skip target mn_data
* start target mi_data
  Retrieving data for MI-MI
* built target mi_data
* end pipeline
Warning messages:
1: package 'targets' was built under R version 4.0.5 
2: package 'ggplot2' was built under R version 4.0.5 
3: package 'tibble' was built under R version 4.0.5 
4: package 'tidyr' was built under R version 4.0.5 
5: package 'readr' was built under R version 4.0.5 
6: package 'purrr' was built under R version 4.0.5 
7: package 'stringr' was built under R version 4.0.5 
8: package 'dataRetrieval' was built under R version 4.0.5 
9: 1 targets produced warnings. Run tar_meta(fields = warnings) for the messages.
```