### PR TITLE
Splitter

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,6 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI','IL')
+states <- c('WI','MN','MI','IL','IN','IA')
 parameter <- c('00060')
 
 # Targets
@@ -26,7 +26,18 @@ list(
   # PULL SITE DATA
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory,
+               {
+                 oldest_active_sites %>%
+                   filter(state_cd == state_abb)
+               }
+    ),
+    tar_target(nwis_data,
+               get_site_data(
+                 nwis_inventory,
+                 state_abb,
+                 parameter)
+    )
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),


### PR DESCRIPTION
* Create splitter target to filter `oldest_active_sites` by each state abbreviation, and then, for each state, pass that filtered tibble to the `get_site_data()` function

Here's my `tar_make()` output:
``` r
> tar_make()
* start target oldest_active_sites
  Inventorying sites in WI
  Inventorying sites in MN
  Inventorying sites in MI
  Inventorying sites in IL
  Inventorying sites in IN
  Inventorying sites in IA
* built target oldest_active_sites
* start target nwis_inventory_MI
* built target nwis_inventory_MI
* start target nwis_inventory_WI
* built target nwis_inventory_WI
* start target nwis_inventory_IA
* built target nwis_inventory_IA
* start target nwis_inventory_MN
* built target nwis_inventory_MN
* start target site_map_png
* built target site_map_png
* start target nwis_inventory_IL
* built target nwis_inventory_IL
* start target nwis_inventory_IN
* built target nwis_inventory_IN
v skip target nwis_data_MI
v skip target nwis_data_WI
* start target nwis_data_IA
  Retrieving data for IA-IA
* built target nwis_data_IA
v skip target nwis_data_MN
v skip target nwis_data_IL
* start target nwis_data_IN
  Retrieving data for IN-IN
* built target nwis_data_IN
* end pipeline
Warning messages:
1: package 'targets' was built under R version 4.0.5 
2: package 'tibble' was built under R version 4.0.5 
3: package 'ggplot2' was built under R version 4.0.5 
4: package 'tidyr' was built under R version 4.0.5 
5: package 'readr' was built under R version 4.0.5 
6: package 'purrr' was built under R version 4.0.5 
7: package 'stringr' was built under R version 4.0.5 
8: package 'dataRetrieval' was built under R version 4.0.5 
9: 1 targets produced warnings. Run tar_meta(fields = warnings) for the messages. 
```

Adding the two new states to the `states` vector triggered a rebuild of `oldest_active_sites`, which meant that the pipeline re-inventoried sites in each of the states, not just the new states. _Then_ b/c `oldest_active_sites` had been rebuilt, each of the `nwis_inventory_*` targets were rebuilt, as they each are a filtered version of the tibble. However, because of that splitting, site data was then pulled _only_ for the two newly added states, and was not re-pulled for the other states.