### PR TITLE
Combiners

### DIFF
--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,0 +1,8 @@
+summarize_targets <- function(ind_file, ...) {
+  ind_tbl <- tar_meta(c(...)) %>%
+    select(tar_name = name, filepath = path, hash = data) %>%
+    mutate(filepath = unlist(filepath))
+
+  readr::write_csv(ind_tbl, ind_file)
+  return(ind_file)
+}

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -9,3 +9,8 @@ tally_site_obs <- function(site_data) {
     group_by(Site, State, Year) %>%
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
 }
+
+# function to combine all site tallies
+combine_obs_tallies <- function(...) {
+  bind_rows(...)
+}

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,0 +1,7 @@
+tar_name,filepath,hash
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,98290bd288f054d3
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,30c5378c6515e68c
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,d2dffdd340593b85
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,89f3823f4e4cae0d
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,0d650597f908f758
+timeseries_png_IA,3_visualize/out/timeseries_IA.png,385b8609bc8aa5e2

--- a/_targets.R
+++ b/_targets.R
@@ -5,18 +5,60 @@ library(tibble)
 suppressPackageStartupMessages(library(dplyr))
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot", "lubridate"))
+tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr",
+                            "rnaturalearth", "cowplot", "lubridate",
+                            "leaflet", "leafpop", "htmlwidgets"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
 source("2_process/src/tally_site_obs.R")
+source("2_process/src/summarize_targets.R")
 source("3_visualize/src/map_sites.R")
 source("3_visualize/src/plot_site_data.R")
+source("3_visualize/src/plot_data_coverage.R")
+source("3_visualize/src/map_timeseries.R")
 
 # Configuration
 states <- c('WI','MN','MI','IL','IN','IA')
 parameter <- c('00060')
+
+# Static branching targets
+# PULL SITE DATA
+mapped_by_state_targets <- tar_map(
+  values = tibble(state_abb = states,
+                  state_plot_files = sprintf('3_visualize/out/timeseries_%s.png', state_abb)),
+  names = state_abb,
+  unlist = FALSE,
+  tar_target(nwis_inventory,
+             {
+               oldest_active_sites %>%
+                 filter(state_cd == state_abb)
+             }
+  ),
+  tar_target(nwis_data,
+             get_site_data(
+               nwis_inventory,
+               state_abb,
+               parameter)
+  ),
+  # Insert step for tallying data here
+  tar_target(tally,
+             tally_site_obs(
+               site_data = nwis_data
+             )
+  ),
+  # Insert step for plotting data here
+  tar_target(timeseries_png,
+             plot_site_data(
+               out_file = state_plot_files,
+               site_data = nwis_data,
+               parameter = parameter
+             ),
+             format = 'file'
+  )
+)
+
 
 # Targets
 list(
@@ -26,44 +68,49 @@ list(
     find_oldest_sites(states, parameter)
   ),
 
-  # PULL SITE DATA
-  tar_map(
-    values = tibble(state_abb = states,
-                    state_plot_files = sprintf('3_visualize/out/timeseries_%s.png', state_abb)),
-    names = state_abb,
-    tar_target(nwis_inventory,
-               {
-                 oldest_active_sites %>%
-                   filter(state_cd == state_abb)
-               }
-    ),
-    tar_target(nwis_data,
-               get_site_data(
-                 nwis_inventory,
-                 state_abb,
-                 parameter)
-    ),
-    # Insert step for tallying data here
-    tar_target(tally,
-               tally_site_obs(
-                 site_data = nwis_data
-               )
-    ),
-    # Insert step for plotting data here
-    tar_target(timeseries_png,
-               plot_site_data(
-                 out_file = state_plot_files,
-                 site_data = nwis_data,
-                 parameter = parameter
-               ),
-               format = 'file'
-    )
+  mapped_by_state_targets,
+
+  # combine tallies
+  tar_combine(
+    obs_tallies,
+    mapped_by_state_targets$tally,
+    command = combine_obs_tallies(!!!.x)
+  ),
+
+  # summarize state data targets
+  tar_combine(
+    summary_state_timeseries_csv,
+    mapped_by_state_targets$timeseries_png,
+    command = summarize_targets(
+      '3_visualize/log/summary_state_timeseries.csv',
+      !!!.x),
+    format = "file"
+  ),
+
+  # plot data coverage
+  tar_target(
+    data_coverage_png,
+    plot_data_coverage(
+      oldest_site_tallies = obs_tallies,
+      out_file = '3_visualize/out/data_coverage.png',
+      parameter = parameter),
+    format = "file"
   ),
 
   # Map oldest sites
   tar_target(
     site_map_png,
     map_sites("3_visualize/out/site_map.png", oldest_active_sites),
+    format = "file"
+  ),
+
+  # generate leaflet map of site data
+  tar_target(
+    timeseries_map_html,
+    map_timeseries(
+      site_info = oldest_active_sites,
+      plot_info_csv = summary_state_timeseries_csv,
+      out_file = '3_visualize/out/timeseries_map.html'),
     format = "file"
   )
 )


### PR DESCRIPTION
* Create a `tar_combine` target to combine the observation tallies for the oldest site in each state.
* Create a new target to make use of the combined observation tallies target and plot the #obs per year for the oldest site in each state.
* Create a second `tar_combine` target to summarize the output of the `timeseries_png` static branching targets, to track the filename and hash of those state-specific timeseries plots.
* Add a final target to generate a leaflet map with the location of the oldest site in each state and the associated timeseries plot.

![image](https://user-images.githubusercontent.com/54007288/126194246-74245925-5958-41a1-aafd-a4c720e38a17.png)
